### PR TITLE
Fix: spelling mistakes, some PEP8 compliancy, disable broken code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 HyREPL
 =======
 
-NREPL server for Hy. Experminel/Hack project at this very moment.
-The current debug enviorment relies on sockets:
+NREPL server for Hy. Experimental/Hack project at the moment.
+The current debug environment relies on sockets (although temporarily disabled).
 
-1. install these dependencies: `blessings` and `nrepl-python-client`
-2. Connect with netcat too port `13337`.  
-3. Run `client.py` and `main.py` (main.py is the server while client just sends basic commands)   
-4. Watch the magic in the netcat session  
-  
+The project uses python 3 (tested with 3.3, but should work under any 3.x).
+
+1. install these dependencies: `blessings`, `nrepl-python-client`, `hy` and `nose`
+2. Connect with `netcat` to port `13337`.  
+3. Run `client.py` and `main.py` (`main.py` is the server while client just sends basic commands)   
+4. Watch the magic in the `netcat` session  
+
 TODO:  
 1. Fork it (yes, you!)  
-2. Add lisence    
+2. Add license    
 3. Get code running  
 4. Fill in blank stuff  
 5. ???  

--- a/client.py
+++ b/client.py
@@ -2,6 +2,7 @@ import socket
 import sys
 import threading
 import time
+
 from nrepl.bencode import encode, decode
 
 
@@ -26,10 +27,9 @@ def client(ip, port, message):
         sock.close()
         del sock
 
-
 #client(ip, port, {"op": "eval", "code": '(def b 2)'})
 #client(ip, port, {"op": "eval", "code": '(+ 2 b)'})
 client(ip, port, {"op": "eval", "code": '(def a (input))'})
-client(ip,port, {"op": "stdin", "value": "test"})
-client(ip,port, {"op": "eval", "code": "(print a)"})
+client(ip, port, {"op": "stdin", "value": "test"})
+client(ip, port, {"op": "eval", "code": "(print a)"})
 

--- a/hyrepl/repl.py
+++ b/hyrepl/repl.py
@@ -1,14 +1,13 @@
-from hy.lex.machine import Machine
-from hy.compiler import hy_compile
-from hy.importer import ast_compile, hy_eval, import_buffer_to_hst
-from hy.lex import tokenize
-from debug.debugger import debug
 import imp
 import sys
 import traceback
 from io import StringIO
+from hy.lex.machine import Machine
+from hy.compiler import hy_compile
+from hy.importer import ast_compile, hy_eval, import_buffer_to_hst
+from hy.lex import tokenize
 
-
+#from debug.debugger import debug
 
 
 class Repl(object):
@@ -16,7 +15,7 @@ class Repl(object):
 
     def eval(self, code):
         self.ret = []
-        print(code)
+        print("Received: %s" % code)
         try:
             ret = tokenize(code)
         except:
@@ -28,9 +27,9 @@ class Repl(object):
         #sys.stdout = StringIO()
         for i in ret:
             try:
-                print("hmmm")
+                print("Sending code to hy_eval...")
                 p = hy_eval(i, self.mod.__dict__, "__main__")
-                print("evaled")
+                print("Evaluated")
             except:
                 self._format_excp(sys.exc_info())
             else:
@@ -47,8 +46,6 @@ class Repl(object):
         exc_type, exc_value, exc_traceback = trace
         self.ret.append({'status': ['eval-error'], 'ex': exc_type.__name__, 'root-ex': exc_type.__name__})
         self.ret.append({'err': str(exc_value)})
-
-
 
     def eval_file(*args):
         pass

--- a/hyrepl/session.py
+++ b/hyrepl/session.py
@@ -1,20 +1,17 @@
-from hyrepl.repl import Repl
-from debug.debugger import debug
-
 import uuid
 import threading
+
+from hyrepl.repl import Repl
+#from debug.debugger import debug
 
 
 class Session(object):
     def __init__(self, UUID):
         self.repl = Repl()
-
         self.uuid = UUID
-
         # All code is sent with threads so 
         # it is possible to kill off any code that gets stcuk
         self.code_evals = {}
-
         # True = code is being evaluated
         # False = Code have been interrupted
         # None = Nothing is happening 
@@ -33,7 +30,6 @@ class Session(object):
             del self.code_evals[id]
         return eval_code
 
-
     def interrupt(self, id):
         if id not in list(self.code_evals):
             self.status = 'interrupt-id-mismatch' 
@@ -43,3 +39,4 @@ class Session(object):
 
     def ret_sess(self):
         return self.code_evals
+

--- a/main.py
+++ b/main.py
@@ -9,6 +9,5 @@ def main():
     except KeyboardInterrupt:
         t.stop()
 
-
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Fix some of the spelling mistakes. Make the code a bit more PEP8 compliant (still some way to go). Disable the debugger since it was broken, and, outcomment hyrepl.errors since it didn't exist.
