### PR TITLE
(print "x") vs None vs Cider

### DIFF
--- a/HyREPL/middleware/eval.hy
+++ b/HyREPL/middleware/eval.hy
@@ -83,9 +83,9 @@
                      (setv sys.stdout oldout)
                      (.format-excp self (sys.exc-info)))
                    (else
-                     (self.writer {"value" (.getvalue p) "ns" (.get self.msg "ns" "Hy")})
                      (when (and (= (.getvalue p) "None") (bool (.getvalue sys.stdout)))
-                       (self.writer {"out" (.getvalue sys.stdout)}))))))
+                       (self.writer {"out" (.getvalue sys.stdout)}))
+                     (self.writer {"value" (.getvalue p) "ns" (.get self.msg "ns" "Hy")})))))
              (setv sys.stdout oldout)
              (self.writer {"status" ["done"]})))))]
    [format-excp


### PR DESCRIPTION
In Cider, I see the following:

```
Hy> (print "x")
NoneX
Hy>
```

The order is wrong, and there should be a newline between the two, I believe.

Meanwhile on the console where I launched hyrepl from:

```
in: {'code': '(print "X")\n', 'op': 'eval', 'id': '16', 'session': '8c93b68e-c0c4-48fc-899a-1643c7818673'}
out: {'session': '9ead7ab5-7f9f-49cc-87cb-7e5ea9b528e7', 'id': '16', 'ns': 'Hy', 'value': 'None'}
out: {'out': 'X\n', 'id': '16', 'session': '9ead7ab5-7f9f-49cc-87cb-7e5ea9b528e7'}
out: {'status': ['done'], 'id': '16', 'session': '9ead7ab5-7f9f-49cc-87cb-7e5ea9b528e7'}
```