### PR TITLE
feat: support hy==0.17.0

### DIFF
--- a/HyREPL/bencode.hy
+++ b/HyREPL/bencode.hy
@@ -1,4 +1,6 @@
-(defreader b [expr] `(bytes ~expr "utf-8"))
+(require [hy.contrib.walk [let]])
+
+(deftag b [expr] `(bytes ~expr "utf-8"))
 
 
 (defn decode-multiple [thing]
@@ -75,7 +77,7 @@
   #b(.format "i{}e" thing))
 
 (defn encode-str [thing]
-  #b(.format "{}:{}" (len #bthing) thing))
+  #b(.format "{}:{}" (len #b thing) thing))
 
 
 (defn encode-bytes [thing]

--- a/HyREPL/middleware/complete.hy
+++ b/HyREPL/middleware/complete.hy
@@ -5,11 +5,11 @@
 
 (import
   hy.macros hy.compiler hy.core.language
-  [hy.models.symbol [HySymbol]]
   [hy.completer [Completer]])
 
 (import [HyREPL.ops [ops]])
-(require HyREPL.ops)
+(require [HyREPL.ops [defop]]
+         [hy.contrib.walk [let]])
 
 (import [HyREPL.middleware.eval [eval-module]])
 
@@ -29,9 +29,9 @@
     (setv m (re.match r"(\S+(\.[\w-]+)*)\.([\w-]*)$" text))
     (print (dir (. self namespace)))
     (try
-      (let [(, expr attr) (.group m 1 3)
-            expr (.replace expr "_" "-")
-            attr (.replace attr "_" "-")
+      (let [groups (.group m 1 3)
+            expr (.replace (first groups)"_" "-")
+            attr (.replace (second groups )"_" "-")
             obj (eval (HySymbol expr) (. self namespace))
             words (dir obj)
             n (len attr)

--- a/HyREPL/middleware/info.hy
+++ b/HyREPL/middleware/info.hy
@@ -1,11 +1,11 @@
 (import sys inspect)
 
 (import
-  [hy.models.symbol [HySymbol]]
   [HyREPL.ops [ops]]
   [HyREPL.middleware.eval [eval-module]])
 
-(require HyREPL.ops)
+(require [HyREPL.ops [defop]]
+         [hy.contrib.walk [let]])
 
 
 (defn resolve-symbol [sym]

--- a/HyREPL/middleware/test/__init__.hy
+++ b/HyREPL/middleware/test/__init__.hy
@@ -1,5 +1,5 @@
 (import [HyREPL.ops [ops]])
-(require HyREPL.ops)
+(require [HyREPL.ops [*]])
 
 (defop test [s m t]
        {"doc" "Test operation"

--- a/HyREPL/server.hy
+++ b/HyREPL/server.hy
@@ -9,6 +9,8 @@
 ; TODO: move these includes somewhere else
 (import [HyREPL.middleware [test eval complete info]])
 
+(require [hy.contrib.walk [let]])
+
 (defclass ReplServer [ThreadingMixIn TCPServer]
   [allow-reuse-address True])
 
@@ -53,13 +55,19 @@
 
 
 (defmain [&rest args]
-  (let [port (if (last args) (int (last args)) 1337)]
-    (while True
-      (try
-        (start-server "127.0.0.1" port)
-        (except [e OSError]
-          (setv port (inc port)))
-        (else
-          (print (.format "Listening on {}" port) :file sys.stderr)
-          (while True
-            (time.sleep 1)))))))
+  (setv port
+        (if (> (len args) 0)
+            (try
+              (int (last args))
+              (except [_ ValueError]
+                1337))
+            1337))
+  (while True
+    (try
+       (start-server "127.0.0.1" port)
+       (except [e OSError]
+         (setv port (inc port)))
+       (else
+         (print (.format "Listening on {}" port) :file sys.stderr)
+         (while True
+           (time.sleep 1))))))

--- a/HyREPL/session.hy
+++ b/HyREPL/session.hy
@@ -4,7 +4,7 @@
   [HyREPL.ops [find-op]])
 
 
-(def sessions {})
+(setv sessions {})
 
 
 (defclass Session [object]

--- a/HyREPL/workarounds.hy
+++ b/HyREPL/workarounds.hy
@@ -2,8 +2,10 @@
 ; It prevents us from having to fork all sorts of clients though, so we got that going for, which is nice.
 
 (import traceback)
+(require [hy.contrib.walk [let]])
 
-(def workarounds {})
+(setv workarounds {})
+
 (defmacro def-workaround [match args &rest body]
   `(assoc workarounds ~match (fn ~args ~@body)))
 

--- a/tests/defop.hy
+++ b/tests/defop.hy
@@ -2,6 +2,7 @@
 
 (import [HyREPL.ops [ops find-op]])
 (require HyREPL.ops)   ; for `defop`
+(require [hy.contrib.walk [let]])
 
 (defmacro assert-multi [&rest cases]
   (let [[s (list-comp `(assert ~c) [c cases])]]

--- a/tests/tests.hy
+++ b/tests/tests.hy
@@ -6,45 +6,44 @@
 (import [HyREPL.bencode [encode decode decode-multiple]])
 (import [HyREPL.server [ReplRequestHandler]])
 
-(defreader b [expr] `(bytes ~expr "utf-8"))
+(require [hy.contrib.walk [let]])
+
+(deftag b [expr] `(bytes ~expr "utf-8"))
 
 (defmacro assert-multi [&rest cases]
-  (let [[s (list-comp `(assert ~c) [c cases])]]
+  (let [[s (lfor c cases `(assert ~c))]]
     `(do ~s)))
 
 (def sock "/tmp/HyREPL-test")
 (defclass ReplUnixStreamServer [ThreadingMixIn UnixStreamServer])
 (defclass TestServer []
-  [[--init--
-     (fn [self]
-       (try
-         (os.unlink sock)
-         (except [e FileNotFoundError]))
-       (setv self.o sys.stderr)
-       (setv self.s (ReplUnixStreamServer sock ReplRequestHandler))
-       (setv self.t (threading.Thread :target (. self s serve-forever)))
-       (setv (. self t daemon) True)
-       (setv sys.stderr (StringIO))
-       None)]
-   [--enter--
-     (fn [self]
-       (.start self.t)
-       self)]
-   [--exit--
-     (fn [self &rest args]
-       (.shutdown self.s)
-       (setv sys.stderr self.o)
-       (.join self.t))]])
+  (defn --init-- [self]
+    (try
+      (os.unlink sock)
+      (except [e FileNotFoundError]))
+    (setv self.o sys.stderr)
+    (setv self.s (ReplUnixStreamServer sock ReplRequestHandler))
+    (setv self.t (threading.Thread :target (. self s serve-forever)))
+    (setv (. self t daemon) True)
+    (setv sys.stderr (StringIO))
+    None)
+  (defn --enter-- [self]
+    (.start self.t)
+    self)
+  (defn --exit-- [self &rest args]
+    (.shutdown self.s)
+    (setv sys.stderr self.o)
+    (.join self.t)))
 
 
 (defn soc-send [message &optional [return-reply True]]
-  (let [[s (socket.socket :family socket.AF-UNIX)]
-        [r []]]
+  (let [s (socket.socket :family socket.AF-UNIX)
+        r []]
     (.connect s sock)
     (.sendall s (encode message))
     (when return-reply
       (.setblocking s False)
-      (let [[buf #b""]]
+      (let [buf #b ""]
         (while True
           (try
             (+= buf (.recv s 1))
@@ -62,12 +61,12 @@
 
 
 (defn test-bencode []
-  (let [[d {"foo" 42 "spam" [1 2 "a"]}]]
+  (let [d {"foo" 42 "spam" [1 2 "a"]}]
     (assert (= d (-> d encode decode first))))
 
-  (let [[d (decode-multiple (+
-                              #b"d5:value1:47:session36:31594b80-7f2e-4915-9969-f1127d562cc42:ns2:Hye"
-                              #b"d6:statusl4:donee7:session36:31594b80-7f2e-4915-9969-f1127d562cc4e"))]]
+  (let [d (decode-multiple (+
+                             #b"d5:value1:47:session36:31594b80-7f2e-4915-9969-f1127d562cc42:ns2:Hye"
+                             #b"d6:statusl4:donee7:session36:31594b80-7f2e-4915-9969-f1127d562cc4e"))]
     (assert-multi
       (= (len d) 2)
       (instance? dict (first d))
@@ -85,11 +84,12 @@
   [{'session': '0361c419-ef89-4a86-ae1a-48388be56041', 'ns': 'Hy', 'value': '4'}, 
                {'status': ['done'], 'session': '0361c419-ef89-4a86-ae1a-48388be56041'}]
   "
-  (with [[(TestServer)]]
-        (let [[code {"op" "eval" "code" "(+ 2 2)"}]
-              [ret (soc-send code)]
-              [(, value status) ret]]
-          (assert-multi
+  (with [(TestServer)]
+    (let [code {"op" "eval" "code" "(+ 2 2)"}
+          ret (soc-send code)
+          value (first ret)
+          status (second ret)]
+      (assert-multi
             (= (len ret) 2)
             (= (. value ["value"]) "4")
             (in "done" (. status ["status"]))
@@ -103,11 +103,13 @@
                {'session': '2d6b48d8-4a3e-49a6-9131-3321a11f70d4', 'out': 'Hello World\n'},
                {'status': ['done'], 'session': '2d6b48d8-4a3e-49a6-9131-3321a11f70d4'}]
   "
-  (with [[(TestServer)]]
-        (let [[code {"op" "eval" "code" "(print \"Hello World\")"}]
-              [ret (soc-send code)]
-              [(, value out status) ret]]
-          (assert-multi
+  (with [(TestServer)]
+    (let [code {"op" "eval" "code" "(print \"Hello World\")"}
+          ret (soc-send code)
+          value (first ret)
+          out (second ret)
+          status (nth ret 2)]
+      (assert-multi
             (= (len ret) 3)
             (= (. value ["value"]) "None")
             (= (. out ["out"]) "Hello World\n")
@@ -131,10 +133,10 @@
          {'session': 'ec100813-8e76-4d69-9116-6460c1db4428', 'ns': 'Hy', 'value': 'test'},
          {'status': ['done'], 'session': 'ec100813-8e76-4d69-9116-6460c1db4428'}]
     "
-    (with [[(TestServer)]]
-          (let [[my-queue (queue.Queue)]
-                [code {"op" "eval" "code" "(def a (input))"}]
-                [t (threading.Thread :target stdin-send :args [code my-queue])]]
+    (with [(TestServer)]
+      (let [my-queue (queue.Queue)
+            code {"op" "eval" "code" "(def a (input))"}
+            t (threading.Thread :target stdin-send :args [code my-queue])]
             (.start t)
             ; Might encounter a race condition where
             ; we send stdin before we eval (input)
@@ -144,11 +146,13 @@
 
             (.join t)
 
-            (let [[ret (.get my-queue)]
-                  [(, input-request value status) ret]]
-              (assert-multi
-                (= (len ret) 3)
-                (= (. value ["value"]) "test")
-                (= (. input-request ["status"]) ["need-input"])
-                (in "done" (. status ["status"]))
-                (= (. value ["session"]) (. input-request ["session"]) (. status ["session"])))))))
+        (let [ret (.get my-queue)
+              input-request (first ret)
+              value (second ret)
+              status (nth ret 2)]
+          (assert-multi
+            (= (len ret) 3)
+            (= (. value ["value"]) "test")
+            (= (. input-request ["status"]) ["need-input"])
+            (in "done" (. status ["status"]))
+            (= (. value ["session"]) (. input-request ["session"]) (. status ["session"])))))))


### PR DESCRIPTION
I believe that this upgrades HyREPL to work with hy 0.17.0. I tested it with the python nrepl client (minimally, basically only eval) and it worked. I don't have it working with CIDER yet, but I'm not sure that that's actually a HyREPL issue. I may add a patch that adds some workarounds once I get it sorted.