### PR TITLE
Fix bug in `bencode.decode-list` where decoding fails for empty list

### DIFF
--- a/HyREPL/bencode.hy
+++ b/HyREPL/bencode.hy
@@ -35,12 +35,11 @@
 
 (defn decode-list [thing]
   (let [rv [] i (,) t thing]
-    (while (> (len t) 0)
+    (while (and (> (len t) 0)
+                (not (.startswith t #b"e")))
       (setv i (decode t))
       (.append rv (first i))
-      (setv t (second i))
-      (when (.startswith t #b"e")
-        (break)))
+      (setv t (second i)))
     (when (= (len t) 0)
       (raise (ValueError "List without end marker")))
     (, rv (cut t 1))))

--- a/HyREPL/session.hy
+++ b/HyREPL/session.hy
@@ -31,6 +31,8 @@
       (.sendall transport (bencode.encode msg))
       (except [e OSError]
         (print (.format "Client gone: {}" e) :file sys.stderr))))
-  (defn handle [self msg transport]
+  (defn handle [self msg transport cooperative]
+    (when (= (.get msg "op") "eval")
+      (assoc msg "cooperative" cooperative))
     (print "in:" msg :file sys.stderr)
     ((find-op (.get msg "op")) self msg transport)))

--- a/HyREPL/workarounds.hy
+++ b/HyREPL/workarounds.hy
@@ -81,3 +81,7 @@
                 [session msg]
                 "(do (import traceback) (.print_last traceback))")
 
+(def-workaround "(seq (.split (System/getProperty \"java.class.path\") \":\"))"
+                [session msg]
+  "(do (import sys) sys.path)")
+


### PR DESCRIPTION
In the case of an empty list, the `thing` to decode is the byte array [b'l', b'e'], i.e. the
list marker "l" followed immediately by the end marker "e".

Previously, we would incorrectly attempt to decode the end marker in this case.
We should make the end marker detection part of the `while` condition so that
the return value will be an empty list and the rest of the input will be
correctly decoded.

In particular, this resulted in an error any time I tried to evaluate an expression using `cider` (version `1.2.0snapshot`)